### PR TITLE
fix: log4j2 variable usage error

### DIFF
--- a/config/connect-log4j2.properties
+++ b/config/connect-log4j2.properties
@@ -22,13 +22,13 @@ appender.stdout.name=STDOUT
 appender.stdout.layout.type=PatternLayout
 
 # Send the logs to a file, rolling the file at midnight local time. For example, the `File` option specifies the
-# location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
+# location of the log files (e.g. ${sys:kafka.logs.dir}/connect.log), and at midnight local time the file is closed
 # and compressed in the same directory but with a filename that ends in the `DatePattern` option.
 #
 appender.connectAppender.type=RollingFile
 appender.connectAppender.name=CONNECT_APPENDER
-appender.connectAppender.fileName=${kafka.logs.dir}/connect.log
-appender.connectAppender.filePattern=${kafka.logs.dir}/connect.log.%d{yyyy-MM-dd}.log.gz
+appender.connectAppender.fileName=${sys:kafka.logs.dir}/connect.log
+appender.connectAppender.filePattern=${sys:kafka.logs.dir}/connect.log.%d{yyyy-MM-dd}.log.gz
 appender.connectAppender.layout.type=PatternLayout
 appender.connectAppender.policies.type=Policies
 appender.connectAppender.policies.time.type=TimeBasedTriggeringPolicy
@@ -44,8 +44,8 @@ appender.connectAppender.strategy.max=1
 connect.log.pattern=[%d] %p %m (%c:%L)%n
 #connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 
-appender.stdout.layout.pattern=${connect.log.pattern}
-appender.connectAppender.layout.pattern=${connect.log.pattern}
+appender.stdout.layout.pattern=${sys:connect.log.pattern}
+appender.connectAppender.layout.pattern=${sys:connect.log.pattern}
 
 rootLogger.level=INFO
 rootLogger.appenderRefs=stdout,connectAppender

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -24,8 +24,8 @@ appender.stdout.layout.pattern=[%d] %p %m (%c)%n
 
 appender.kafkaAppender.type=RollingFile
 appender.kafkaAppender.name=KAFKA_APPENDER
-appender.kafkaAppender.fileName=${kafka.logs.dir}/server.log
-appender.kafkaAppender.filePattern=${kafka.logs.dir}/server.log.%d{yyyy-MM-dd}.log.gz
+appender.kafkaAppender.fileName=${sys:kafka.logs.dir}/server.log
+appender.kafkaAppender.filePattern=${sys:kafka.logs.dir}/server.log.%d{yyyy-MM-dd}.log.gz
 appender.kafkaAppender.layout.type=PatternLayout
 appender.kafkaAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.kafkaAppender.policies.type=Policies
@@ -37,8 +37,8 @@ appender.kafkaAppender.strategy.max=1
 
 appender.requestAppender.type=RollingFile
 appender.requestAppender.name=REQUEST_APPENDER
-appender.requestAppender.fileName=${kafka.logs.dir}/kafka-request.log
-appender.requestAppender.filePattern=${kafka.logs.dir}/kafka-request.log.%d{yyyy-MM-dd}.log.gz
+appender.requestAppender.fileName=${sys:kafka.logs.dir}/kafka-request.log
+appender.requestAppender.filePattern=${sys:kafka.logs.dir}/kafka-request.log.%d{yyyy-MM-dd}.log.gz
 appender.requestAppender.layout.type=PatternLayout
 appender.requestAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.requestAppender.policies.type=Policies
@@ -50,8 +50,8 @@ appender.requestAppender.strategy.max=1
 
 appender.controllerAppender.type=RollingFile
 appender.controllerAppender.name=CONTROLLER_APPENDER
-appender.controllerAppender.fileName=${kafka.logs.dir}/controller.log
-appender.controllerAppender.filePattern=${kafka.logs.dir}/controller.log.%d{yyyy-MM-dd}.log.gz
+appender.controllerAppender.fileName=${sys:kafka.logs.dir}/controller.log
+appender.controllerAppender.filePattern=${sys:kafka.logs.dir}/controller.log.%d{yyyy-MM-dd}.log.gz
 appender.controllerAppender.layout.type=PatternLayout
 appender.controllerAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.controllerAppender.policies.type=Policies
@@ -63,8 +63,8 @@ appender.controllerAppender.strategy.max=1
 
 appender.cleanerAppender.type=RollingFile
 appender.cleanerAppender.name=CLEANER_APPENDER
-appender.cleanerAppender.fileName=${kafka.logs.dir}/log-cleaner.log
-appender.cleanerAppender.filePattern=${kafka.logs.dir}/log-cleaner.log.%d{yyyy-MM-dd}.log.gz
+appender.cleanerAppender.fileName=${sys:kafka.logs.dir}/log-cleaner.log
+appender.cleanerAppender.filePattern=${sys:kafka.logs.dir}/log-cleaner.log.%d{yyyy-MM-dd}.log.gz
 appender.cleanerAppender.layout.type=PatternLayout
 appender.cleanerAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.cleanerAppender.policies.type=Policies
@@ -76,8 +76,8 @@ appender.cleanerAppender.strategy.max=1
 
 appender.stateChangeAppender.type=RollingFile
 appender.stateChangeAppender.name=STATE_CHANGE_APPENDER
-appender.stateChangeAppender.fileName=${kafka.logs.dir}/state-change.log
-appender.stateChangeAppender.filePattern=${kafka.logs.dir}/state-change.log.%d{yyyy-MM-dd}.log.gz
+appender.stateChangeAppender.fileName=${sys:kafka.logs.dir}/state-change.log
+appender.stateChangeAppender.filePattern=${sys:kafka.logs.dir}/state-change.log.%d{yyyy-MM-dd}.log.gz
 appender.stateChangeAppender.layout.type=PatternLayout
 appender.stateChangeAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.stateChangeAppender.policies.type=Policies
@@ -89,8 +89,8 @@ appender.stateChangeAppender.strategy.max=1
 
 appender.authorizerAppender.type=RollingFile
 appender.authorizerAppender.name=AUTHORIZER_APPENDER
-appender.authorizerAppender.fileName=${kafka.logs.dir}/kafka-authorizer.log
-appender.authorizerAppender.filePattern=${kafka.logs.dir}/kafka-authorizer.log.%d{yyyy-MM-dd}.log.gz
+appender.authorizerAppender.fileName=${sys:kafka.logs.dir}/kafka-authorizer.log
+appender.authorizerAppender.filePattern=${sys:kafka.logs.dir}/kafka-authorizer.log.%d{yyyy-MM-dd}.log.gz
 appender.authorizerAppender.layout.type=PatternLayout
 appender.authorizerAppender.layout.pattern=[%d] %p %m (%c)%n
 appender.authorizerAppender.policies.type=Policies


### PR DESCRIPTION
when only use `${kafka.logs.dir}`, log4j2 will create a dictionary name `${kafka.logs.dir}`, rather than the log path specifed by -Dkafka.logs.dir